### PR TITLE
RoundOverlayのアニメーションを1度だけ実行するよう修正

### DIFF
--- a/apps/web/src/pages/GameScreen.tsx
+++ b/apps/web/src/pages/GameScreen.tsx
@@ -108,6 +108,10 @@ export default function GameScreen({ rule, onExit, onOptions, lang, onToggleLang
     resetSequence();
   }
 
+  const findCard = useCallback((hand: Hand, name: string): FoodCard | null => {
+    return rule.deck.find(c => c.hand === hand && c.name === name) || null;
+  }, [rule.deck]);
+
   const handleAssign = useCallback((names: Record<Hand, string>) => {
     const next: Partial<Record<Hand, FoodCard>> = {};
     (['rock','scissors','paper'] as Hand[]).forEach((h) => {
@@ -118,12 +122,7 @@ export default function GameScreen({ rule, onExit, onOptions, lang, onToggleLang
       }
     });
     setAssigned(next);
-  }, [rule.deck]);
-
-  // 抽選結果をデッキにマップ
-  function findCard(hand: Hand, name: string): FoodCard | null {
-    return rule.deck.find(c => c.hand === hand && c.name === name) || null;
-  }
+  }, [findCard]);
 
   return (
     <Box px={{ base: 0, md: 0 }} py={0} color={isDark ? 'whiteAlpha.900' : 'gray.900'}>


### PR DESCRIPTION
## 概要
- RoundOverlayでアニメーションをラウンド毎に1回だけ実行するよう`useRef`フラグを追加
- アニメーション重複時にエラーとして処理しつつ、例外発生時はフラグをリセット
- GameScreenのuseCallback依存関係を整理してlint警告を解消

## テスト
- `npm run lint`
- `npm run build` (型エラーで失敗)
- `npm run dev` (起動を確認)


------
https://chatgpt.com/codex/tasks/task_e_68a1a569cfb4832ab99d1bbf87c0f37b