### PR TITLE
web: useEffectの初回判定でアニメーション多重実行を防止

### DIFF
--- a/apps/web/src/components/RoundOverlay.tsx
+++ b/apps/web/src/components/RoundOverlay.tsx
@@ -46,8 +46,12 @@ export default function RoundOverlay({ round = 1, onComplete, onResult }: Props)
   const slotBox2 = useRef<HTMLDivElement>(null);
   const slotBox3 = useRef<HTMLDivElement>(null);
   const hasAnimated = useRef(false);
+  const lastRound = useRef<number | undefined>();
+  const lastStep = useRef<0 | 2 | 3 | null>(null);
 
   useEffect(() => {
+    if (lastRound.current === round) return;
+    lastRound.current = round;
     hasAnimated.current = false;
     // 通常シーケンス: ROUND -> SLOT
     setStep(2);
@@ -59,6 +63,8 @@ export default function RoundOverlay({ round = 1, onComplete, onResult }: Props)
   }, [round]);
 
   useEffect(() => {
+    if (lastStep.current === step) return;
+    lastStep.current = step;
     let killed = false;
     ensureGsap().then(() => {
       if (killed) return;

--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -15,8 +15,11 @@ function ensureGsap(): Promise<void> {
 export function useGameStartAnimation(onComplete: () => void) {
   const [visible, setVisible] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasRun = useRef(false);
 
   useEffect(() => {
+    if (hasRun.current) return;
+    hasRun.current = true;
     let killed = false;
     ensureGsap().then(() => {
       if (killed) return;


### PR DESCRIPTION
## 概要
- useGameStartAnimationとRoundOverlayでuseEffectの初回実行をuseRefで判定
- React Strict Modeでの二重アニメーションを抑止

## テスト
- `npm run lint`
- `npm run build` (型エラーで失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a1d3512bf8832aaf81dc84f0e90f4e