### PR TITLE
カルーセルをカードゲームと同じ縦長サイズに調整

### DIFF
--- a/apps/web/src/components/JankenSwiper.tsx
+++ b/apps/web/src/components/JankenSwiper.tsx
@@ -28,44 +28,51 @@ export default function JankenSwiper({ onSelect, cards }: Props) {
   }, [swiper]);
 
   return (
-    <VStack gap={4} w='full' maxW='720px'>
-      <Box w='full' position="relative" px="12">
-        <Swiper
-          modules={[Navigation]}
-          onSwiper={setSwiper}
-          slidesPerView={1}
-          spaceBetween={30}
-          navigation
-        >
-          {HANDS.map((h) => {
-            const colorScheme = handColors[h];
-            return (
-              <SwiperSlide key={h} onClick={() => onSelect(h)}>
-                <VStack
-                  h='200px'
-                  borderRadius='lg'
-                  bg={colorScheme.bg}
-                  color={colorScheme.color}
-                  justify='center'
-                  userSelect='none'
-                  cursor='pointer'
-                >
-                  <Text fontSize='56px' lineHeight={1}>{HAND_EMOJI[h]}</Text>
-                  <Text fontSize='lg' fontWeight='bold'>{HAND_LABEL[h]}</Text>
-                  {cards?.[h] ? (
-                    <VStack gap={0} fontSize='sm' opacity={0.9}>
-                      <Text fontWeight='semibold'>{cards[h]!.name}</Text>
-                      <Text>+{cards[h]!.points}pt / 満腹+{cards[h]!.satiety}</Text>
-                    </VStack>
-                  ) : (
-                    <Text mt={2} fontSize="lg" fontWeight="bold">???</Text>
-                  )}
-                </VStack>
-              </SwiperSlide>
-            );
-          })}
-        </Swiper>
-      </Box>
-    </VStack>
+    <Box w='full' maxW={{ base: '200px', md: '600px' }} mx='auto' py={4}>
+      <Swiper
+        modules={[Navigation]}
+        onSwiper={setSwiper}
+        slidesPerView={1}
+        spaceBetween={30}
+        navigation
+        centeredSlides
+        breakpoints={{
+          768: {
+            slidesPerView: 3,
+            spaceBetween: 40,
+            centeredSlides: false,
+          },
+        }}
+      >
+        {HANDS.map((h) => {
+          const colorScheme = handColors[h];
+          return (
+            <SwiperSlide key={h} onClick={() => onSelect(h)}>
+              <VStack
+                w='full'
+                h='360px'
+                borderRadius='lg'
+                bg={colorScheme.bg}
+                color={colorScheme.color}
+                justify='center'
+                userSelect='none'
+                cursor='pointer'
+              >
+                <Text fontSize='56px' lineHeight={1}>{HAND_EMOJI[h]}</Text>
+                <Text fontSize='lg' fontWeight='bold'>{HAND_LABEL[h]}</Text>
+                {cards?.[h] ? (
+                  <VStack gap={0} fontSize='sm' opacity={0.9}>
+                    <Text fontWeight='semibold'>{cards[h]!.name}</Text>
+                    <Text>+{cards[h]!.points}pt / 満腹+{cards[h]!.satiety}</Text>
+                  </VStack>
+                ) : (
+                  <Text mt={2} fontSize="lg" fontWeight="bold">???</Text>
+                )}
+              </VStack>
+            </SwiperSlide>
+          );
+        })}
+      </Swiper>
+    </Box>
   );
 }


### PR DESCRIPTION
## 概要
- じゃんけん選択カルーセルのカードを縦長サイズに統一
- 画面幅に応じて1枚/3枚表示を切り替え

## テスト
- `npm test` (スクリプトなし)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c24961b0832a978eac41a6be8968