### PR TITLE
ダイアログの背景色を白に修正

### DIFF
--- a/apps/web/src/pages/PlayerSelectScreen.tsx
+++ b/apps/web/src/pages/PlayerSelectScreen.tsx
@@ -49,7 +49,7 @@ export default function PlayerSelectScreen({ onBack, onConfirm }: Props) {
       <Dialog.Root open={confirmOpen} onOpenChange={(e) => setConfirmOpen(e.open)}>
         <Dialog.Backdrop />
         <Dialog.Positioner>
-          <Dialog.Content>
+          <Dialog.Content bg='white' _dark={{ bg: 'gray.800' }}>
             <Dialog.Header>
               <Dialog.Title>確認</Dialog.Title>
             </Dialog.Header>


### PR DESCRIPTION
## 概要
- プレイヤー選択画面のダイアログ背景を白色に設定し、不透明度を改善

## テスト
- `npm run lint`
- `npm run build` *(TypeScript エラーで失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68a445a795f8832ab59e1a5670345e94