### PR TITLE
web: show player names in round overlay

### DIFF
--- a/apps/web/src/components/JankenCarousel.tsx
+++ b/apps/web/src/components/JankenCarousel.tsx
@@ -2,7 +2,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
-import { Box, Card, CardBody, Heading, Text, VStack } from '@chakra-ui/react';
+import { Box, Heading, Text, VStack } from '@chakra-ui/react';
 import type { FoodCard, Hand } from '@/models';
 import { HAND_LABEL, HAND_EMOJI } from '@/models';
 
@@ -47,7 +47,7 @@ export default function JankenCarousel({ onSelect, cards }: Props) {
 
           return (
             <SwiperSlide key={hand}>
-              <Card
+              <VStack
                 as="button"
                 onClick={() => onSelect(hand)}
                 w="full"
@@ -58,22 +58,22 @@ export default function JankenCarousel({ onSelect, cards }: Props) {
                 transition="all 0.2s"
                 _hover={{ transform: 'scale(1.05)', shadow: 'xl' }}
                 overflow="hidden"
+                justify="center"
+                gap={2}
               >
-                <CardBody as={VStack} justify="center" spacing={2}>
-                  <Text fontSize="6xl">{HAND_EMOJI[hand]}</Text>
-                  <Heading size="md">{HAND_LABEL[hand]}</Heading>
-                  {card ? (
-                    <VStack spacing={0} mt={2}>
-                      <Text fontWeight="bold" fontSize="lg">{card.name}</Text>
-                      <Text fontSize="sm" opacity={0.9}>
-                        {card.points}pt / 満腹{card.satiety}
-                      </Text>
-                    </VStack>
-                  ) : (
-                    <Text mt={2} fontSize="lg" fontWeight="bold">???</Text>
-                  )}
-                </CardBody>
-              </Card>
+                <Text fontSize="6xl">{HAND_EMOJI[hand]}</Text>
+                <Heading size="md">{HAND_LABEL[hand]}</Heading>
+                {card ? (
+                  <VStack gap={0} mt={2}>
+                    <Text fontWeight="bold" fontSize="lg">{card.name}</Text>
+                    <Text fontSize="sm" opacity={0.9}>
+                      {card.points}pt / 満腹{card.satiety}
+                    </Text>
+                  </VStack>
+                ) : (
+                  <Text mt={2} fontSize="lg" fontWeight="bold">???</Text>
+                )}
+              </VStack>
             </SwiperSlide>
           );
         })}

--- a/apps/web/src/components/RoundOverlay.tsx
+++ b/apps/web/src/components/RoundOverlay.tsx
@@ -6,6 +6,9 @@ import { ensureGsap } from '@/lib';
 
 type Props = {
   round?: number;
+  mode?: 'pvc' | 'pvp';
+  playerName?: string;
+  cpuName?: string;
   onComplete: () => void;
   debugStep?: 2 | 3; // デバッグ用: 特定ステップのみ
   onResult?: (names: Record<Hand, string>) => void; // 選ばれた食品名（手ごと）
@@ -24,7 +27,7 @@ const seqRock = Array.from({ length: cycles }).flatMap(() => slotFoods.rock);
 const seqScis = Array.from({ length: cycles }).flatMap(() => slotFoods.scissors);
 const seqPap  = Array.from({ length: cycles }).flatMap(() => slotFoods.paper);
 
-export default function RoundOverlay({ round = 1, onComplete, onResult }: Props) {
+export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuName, onComplete, onResult }: Props) {
   const [step, setStep] = useState<0 | 2 | 3>(0);
   const [visible, setVisible] = useState(true);
   const [resultFoods, setResultFoods] = useState<string[] | null>(null);
@@ -37,8 +40,10 @@ export default function RoundOverlay({ round = 1, onComplete, onResult }: Props)
   const slotBox2 = useRef<HTMLDivElement>(null);
   const slotBox3 = useRef<HTMLDivElement>(null);
   const hasAnimated = useRef(false);
-  const lastRound = useRef<number | undefined>();
+  const lastRound = useRef<number | undefined>(undefined);
   const lastStep = useRef<0 | 2 | 3 | null>(null);
+  const p1Name = playerName ?? (mode === 'pvp' ? 'プレイヤー1' : 'あなた');
+  const p2Name = cpuName ?? (mode === 'pvp' ? 'プレイヤー2' : 'CPU');
 
   useEffect(() => {
     if (lastRound.current === round) return;
@@ -153,10 +158,12 @@ export default function RoundOverlay({ round = 1, onComplete, onResult }: Props)
             fontSize={{ base: '72px', md: '120px', lg: '200px' }}>
             {round}
           </Text>
+          <Text mt={4} fontWeight='bold' fontSize={{ base: '20px', md: '24px' }}>{p1Name} vs {p2Name}</Text>
         </VStack>
       ) : (
         // SLOT (簡略版)
         <VStack gap={{ base: 4, md: 6 }} w='full' maxW='960px'>
+          <Text fontWeight='bold' textAlign='center' fontSize={{ base: '18px', md: '20px' }}>{p1Name} vs {p2Name}</Text>
           <Text fontWeight='extrabold' letterSpacing='.1em' opacity={0.9} textAlign='center' fontSize={{ base: '16px', md: '18px' }}>SLOT</Text>
 
           <HStack w='full' gap={3} align='center' justify='center'>

--- a/apps/web/src/types/swiper-css.d.ts
+++ b/apps/web/src/types/swiper-css.d.ts
@@ -1,2 +1,3 @@
 declare module 'swiper/css';
 declare module 'swiper/css/effect-coverflow';
+declare module 'swiper/css/navigation';


### PR DESCRIPTION
## Summary
- add `mode`, `playerName`, and `cpuName` props to `RoundOverlay`
- show player vs. CPU names during round and slot displays
- fix build by updating `JankenCarousel` and declaring `swiper/css/navigation`

## Testing
- `npm run lint`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a504fd6918832aaeb737426a914930