### PR TITLE
fix(web): デバッグアニメーションの終了制御

### DIFF
--- a/apps/web/src/components/GameStartAnimation.tsx
+++ b/apps/web/src/components/GameStartAnimation.tsx
@@ -6,10 +6,11 @@ type Props = {
   onComplete: () => void;
   playerName?: string;
   cpuName?: string;
+  debug?: boolean;
 };
 
-export default function GameStartAnimation({ onComplete, playerName = 'プレイヤー', cpuName = 'CPU' }: Props) {
-  const { visible, containerRef } = useGameStartAnimation(onComplete);
+export default function GameStartAnimation({ onComplete, playerName = 'プレイヤー', cpuName = 'CPU', debug = false }: Props) {
+  const { visible, containerRef } = useGameStartAnimation(onComplete, debug);
 
   if (!visible) return null;
 

--- a/apps/web/src/components/RoundOverlay.tsx
+++ b/apps/web/src/components/RoundOverlay.tsx
@@ -27,7 +27,7 @@ const seqRock = Array.from({ length: cycles }).flatMap(() => slotFoods.rock);
 const seqScis = Array.from({ length: cycles }).flatMap(() => slotFoods.scissors);
 const seqPap  = Array.from({ length: cycles }).flatMap(() => slotFoods.paper);
 
-export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuName, onComplete, onResult }: Props) {
+export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuName, onComplete, debugStep, onResult }: Props) {
   const [step, setStep] = useState<0 | 2 | 3>(0);
   const [visible, setVisible] = useState(true);
   const [resultFoods, setResultFoods] = useState<string[] | null>(null);
@@ -46,16 +46,16 @@ export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuN
   const p2Name = cpuName ?? (mode === 'pvp' ? 'プレイヤー2' : 'CPU');
 
   useEffect(() => {
-    if (lastRound.current === round) return;
+    if (lastRound.current === round && lastStep.current === debugStep) return;
     lastRound.current = round;
+    lastStep.current = null;
     hasAnimated.current = false;
-    // 通常シーケンス: ROUND -> SLOT
-    setStep(2);
     setShowNext(false);
+    setStep(debugStep ?? 2);
     return () => {
       hasAnimated.current = false;
     };
-  }, [round]);
+  }, [round, debugStep]);
 
   useEffect(() => {
     if (lastStep.current === step) return;
@@ -135,7 +135,22 @@ export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuN
     return () => { killed = true; };
   }, [step, onComplete, onResult]);
 
+  useEffect(() => {
+    if (!debugStep || !showNext) return;
+    const id = setTimeout(() => {
+      setVisible(false);
+      onComplete();
+    }, 600);
+    return () => clearTimeout(id);
+  }, [debugStep, showNext, onComplete]);
+
   function handleNext() {
+    if (debugStep) {
+      setShowNext(false);
+      setVisible(false);
+      onComplete();
+      return;
+    }
     if (step === 2) {
       setShowNext(false);
       setStep(3);
@@ -217,7 +232,7 @@ export default function RoundOverlay({ round = 1, mode = 'pvc', playerName, cpuN
       )}
       {showNext && (
         <Box position='absolute' bottom={{ base: 6, md: 8 }} left='50%' transform='translateX(-50%)'>
-          <Button bg='white' color='black' size='lg' onClick={handleNext} _hover={{ bg: 'gray.100' }}>次へ</Button>
+          <Button bg='white' color='black' size='lg' onClick={handleNext} _hover={{ bg: 'gray.100' }}>{debugStep ? '終了' : '次へ'}</Button>
         </Box>
       )}
     </Box>

--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ensureGsap } from '@/lib';
 
-export function useGameStartAnimation(onComplete: () => void) {
+export function useGameStartAnimation(onComplete: () => void, debug = false) {
   const [visible, setVisible] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasRun = useRef(false);
@@ -19,10 +19,12 @@ export function useGameStartAnimation(onComplete: () => void) {
 
       const tl = gsap.timeline({
         onComplete: () => {
-          setTimeout(() => {
+          const finish = () => {
             setVisible(false);
             onComplete();
-          }, 400);
+          };
+          if (debug) finish();
+          else setTimeout(finish, 400);
         }
       });
 
@@ -30,7 +32,7 @@ export function useGameStartAnimation(onComplete: () => void) {
         .to(containerRef.current, { opacity: 0, duration: 0.4, ease: 'power2.in' }, '>+=0.4');
     });
     return () => { killed = true; };
-  }, [onComplete]);
+  }, [onComplete, debug]);
 
   return { visible, containerRef };
 }

--- a/apps/web/src/pages/TitleScreen.tsx
+++ b/apps/web/src/pages/TitleScreen.tsx
@@ -234,7 +234,7 @@ export default function TitleScreen({ rule, onChangeRule, onStart, onOptions, on
       </Box>
     </Box>
     {showOverlay === 'vs' && (
-      <GameStartAnimation onComplete={() => setShowOverlay('round')} />
+      <GameStartAnimation debug onComplete={() => setShowOverlay(false)} />
     )}
     {(showOverlay === 'round' || showOverlay === 'slot') && (
       <RoundOverlay


### PR DESCRIPTION
## 概要
- デバッグメニューから VS を表示した際に次のアニメーションへ遷移しないよう調整
- RoundOverlay に debugStep を実装し、指定ステップのみ再生＋自動終了
- GameStartAnimation に debug フラグを追加しデバッグ時の終了処理を整理

## テスト
- `cd apps/web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a81389686c832abaf470bcf9f29642