### PR TITLE
web: ゲーム開始アニメに煙エフェクトを追加

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "framer-motion": "^12.23.12",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-smoke-effect": "^1.0.2",
     "swiper": "^11.2.10",
     "ts-node": "^10.9.2"
   },

--- a/apps/web/src/components/GameStartAnimation.tsx
+++ b/apps/web/src/components/GameStartAnimation.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Box, Text, VStack } from '@chakra-ui/react';
+import { useRef, useState } from 'react';
 import { useGameStartAnimation } from './hooks/useGameStartAnimation';
+import SmokeEffect from './effects/SmokeEffect';
 
 type Props = {
   onComplete: () => void;
@@ -9,17 +11,21 @@ type Props = {
 };
 
 export default function GameStartAnimation({ onComplete, playerName = 'プレイヤー', cpuName = 'CPU' }: Props) {
-  const { visible, containerRef } = useGameStartAnimation(onComplete);
+  const playerRef = useRef<HTMLParagraphElement>(null);
+  const cpuRef = useRef<HTMLParagraphElement>(null);
+  const [showSmoke, setShowSmoke] = useState(false);
+  const { visible, containerRef } = useGameStartAnimation(onComplete, playerRef, cpuRef, setShowSmoke);
 
   if (!visible) return null;
 
   return (
     <Box position='fixed' inset={0} bg='rgba(0,0,0,1)' color='white' zIndex={10000} display='grid' placeItems='center' ref={containerRef as any}>
       <VStack gap={{ base: 2, md: 3 }} textAlign='center'>
-        <Text fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{playerName}</Text>
+        <Text ref={playerRef} fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{playerName}</Text>
         <Text fontWeight='extrabold' fontSize={{ base: 'clamp(16px, 5vw, 24px)', md: '24px' }} opacity={0.9}>vs</Text>
-        <Text fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{cpuName}</Text>
+        <Text ref={cpuRef} fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{cpuName}</Text>
       </VStack>
+      {showSmoke && <SmokeEffect />}
     </Box>
   );
 }

--- a/apps/web/src/components/effects/SmokeEffect.tsx
+++ b/apps/web/src/components/effects/SmokeEffect.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@chakra-ui/react';
+import SmokeScene from 'react-smoke-effect';
+
+interface Props {
+  width?: number | string;
+  height?: number | string;
+  top?: number | string;
+  left?: number | string;
+}
+
+export default function SmokeEffect({ width = '200px', height = '200px', top = '50%', left = '50%' }: Props) {
+  return (
+    <Box
+      position='absolute'
+      top={top}
+      left={left}
+      width={width}
+      height={height}
+      transform='translate(-50%, -50%)'
+      pointerEvents='none'
+      overflow='hidden'
+    >
+      <SmokeScene />
+    </Box>
+  );
+}

--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import { ensureGsap } from '@/lib';
 
-export function useGameStartAnimation(onComplete: () => void) {
+export function useGameStartAnimation(
+  onComplete: () => void,
+  playerRef: RefObject<HTMLElement>,
+  cpuRef: RefObject<HTMLElement>,
+  setShowSmoke: (v: boolean) => void
+) {
   const [visible, setVisible] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasRun = useRef(false);
@@ -16,21 +21,27 @@ export function useGameStartAnimation(onComplete: () => void) {
       const gsap: any = (window as any).gsap;
 
       gsap.set(containerRef.current, { opacity: 0 });
+      gsap.set(playerRef.current, { x: '-50vw' });
+      gsap.set(cpuRef.current, { x: '50vw' });
 
-      const tl = gsap.timeline({
-        onComplete: () => {
-          setTimeout(() => {
+      gsap
+        .timeline({
+          onComplete: () => {
             setVisible(false);
             onComplete();
-          }, 400);
-        }
-      });
-
-      tl.to(containerRef.current, { opacity: 1, duration: 0.4, ease: 'power2.out' })
-        .to(containerRef.current, { opacity: 0, duration: 0.4, ease: 'power2.in' }, '>+=0.4');
+          }
+        })
+        .to(containerRef.current, { opacity: 1, duration: 0.2, ease: 'power2.out' })
+        .to(playerRef.current, { x: 0, duration: 0.8, ease: 'back.out(1.7)' }, 0)
+        .to(cpuRef.current, { x: 0, duration: 0.8, ease: 'back.out(1.7)' }, 0)
+        .add(() => setShowSmoke(true))
+        .to(containerRef.current, { opacity: 0, duration: 0.4, ease: 'power2.in' }, '>+=0.4')
+        .add(() => setShowSmoke(false));
     });
-    return () => { killed = true; };
-  }, [onComplete]);
+    return () => {
+      killed = true;
+    };
+  }, [onComplete, playerRef, cpuRef, setShowSmoke]);
 
   return { visible, containerRef };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "framer-motion": "^12.23.12",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-smoke-effect": "^1.0.2",
         "swiper": "^11.2.10",
         "ts-node": "^10.9.2"
       },
@@ -1758,16 +1759,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -3992,6 +3983,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4098,6 +4101,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4278,6 +4290,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
@@ -4359,6 +4382,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-smoke-effect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-smoke-effect/-/react-smoke-effect-1.0.2.tgz",
+      "integrity": "sha512-xsrD7z2inmbZ7VDKtLsJQVK7fB/Y7l9hS6k/VrOL5HnVOkXZOSoIvUoal8vrWvCYBzcwLS+bS1ee/TKGdYZivA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "three": "^0.172.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.8.1",
+        "react": "^16.0.0",
+        "react-dom": "^18.0.0",
+        "three": "^0.160.0"
       }
     },
     "node_modules/resolve": {
@@ -4586,6 +4628,12 @@
         "node": ">= 4.7.0"
       }
     },
+    "node_modules/three": {
+      "version": "0.172.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.172.0.tgz",
+      "integrity": "sha512-6HMgMlzU97MsV7D/tY8Va38b83kz8YJX+BefKjspMNAv0Vx6dxMogHOrnRl/sbMIs3BPUKijPqDqJ/+UwJbIow==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -4726,6 +4774,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4758,13 +4807,6 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",


### PR DESCRIPTION
## 概要
- react-smoke-effect を導入
- GameStartAnimation に煙と左右スライド演出を追加
- アニメ完了時に onComplete を確実に呼ぶようフックを調整

## テスト
- `npm install --legacy-peer-deps`
- `cd apps/web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a814d4b4d4832a813a591a76300f99