### PR TITLE
feat(web): vertical drop game start animation

### DIFF
--- a/apps/web/src/components/GameStartAnimation.tsx
+++ b/apps/web/src/components/GameStartAnimation.tsx
@@ -21,6 +21,7 @@ export default function GameStartAnimation({ onComplete, playerName = 'プレイ
   return (
     <Box position='fixed' inset={0} bg='rgba(0,0,0,1)' color='white' zIndex={10000} display='grid' placeItems='center' ref={containerRef as any}>
       <VStack gap={{ base: 2, md: 3 }} textAlign='center'>
+        {/* 上: プレイヤー名, 下: CPU 名の順序を維持 */}
         <Text ref={playerRef} fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{playerName}</Text>
         <Text fontWeight='extrabold' fontSize={{ base: 'clamp(16px, 5vw, 24px)', md: '24px' }} opacity={0.9}>vs</Text>
         <Text ref={cpuRef} fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{cpuName}</Text>

--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -21,8 +21,8 @@ export function useGameStartAnimation(
       const gsap: any = (window as any).gsap;
 
       gsap.set(containerRef.current, { opacity: 0 });
-      gsap.set(playerRef.current, { x: '-50vw' });
-      gsap.set(cpuRef.current, { x: '50vw' });
+      gsap.set(playerRef.current, { y: '-60vh', rotate: 15 });
+      gsap.set(cpuRef.current, { y: '60vh', rotate: -15 });
 
       gsap
         .timeline({
@@ -32,8 +32,24 @@ export function useGameStartAnimation(
           }
         })
         .to(containerRef.current, { opacity: 1, duration: 0.2, ease: 'power2.out' })
-        .to(playerRef.current, { x: 0, duration: 0.8, ease: 'back.out(1.7)' }, 0)
-        .to(cpuRef.current, { x: 0, duration: 0.8, ease: 'back.out(1.7)' }, 0)
+        .to(
+          playerRef.current,
+          { y: 0, rotate: 0, ease: 'bounce.out', duration: 0.9 },
+          0
+        )
+        .to(
+          cpuRef.current,
+          { y: 0, rotate: 0, ease: 'bounce.out', duration: 0.9 },
+          0
+        )
+        .to(
+          [playerRef.current, cpuRef.current],
+          { y: '+=16', scaleY: 0.9, duration: 0.1, ease: 'power1.in' }
+        )
+        .to(
+          [playerRef.current, cpuRef.current],
+          { y: '-=16', scaleY: 1, duration: 0.2, ease: 'bounce.out' }
+        )
         .add(() => setShowSmoke(true))
         .to(containerRef.current, { opacity: 0, duration: 0.4, ease: 'power2.in' }, '>+=0.4')
         .add(() => setShowSmoke(false));


### PR DESCRIPTION
## Summary
- shift game start animation to vertical drop with bounce
- note order of player and CPU names in start animation

## Testing
- `npm run lint -w web`


------
https://chatgpt.com/codex/tasks/task_e_68a81c708dd4832a8233b3ca7cfa88a1