### PR TITLE
縦方向のゲーム開始アニメを実装

### DIFF
--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -21,11 +21,20 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
       if (killed) return;
       const gsap: any = (window as any).gsap;
 
-      // 初期状態（アンビル: サイドからブラー付きで滑り込み）
+      // 初期状態（アンビル: 上下からブラー付きで滑り込み）
       gsap.set(containerRef.current, { opacity: 0 });
-<<<<<<< HEAD
-      gsap.set(playerRef.current, { x: '-55vw', filter: 'blur(16px)', opacity: 0.2, skewX: -8 });
-      gsap.set(cpuRef.current, { x: '55vw', filter: 'blur(16px)', opacity: 0.2, skewX: 8 });
+      gsap.set(playerRef.current, {
+        y: '-60vh',
+        filter: 'blur(16px)',
+        opacity: 0.2,
+        skewY: -8
+      });
+      gsap.set(cpuRef.current, {
+        y: '60vh',
+        filter: 'blur(16px)',
+        opacity: 0.2,
+        skewY: 8
+      });
 
       const tl = gsap.timeline({
         defaults: { ease: 'expo.out' },
@@ -41,50 +50,40 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
         // スモーク先行発生（ごく短時間で焚く）
         .add(() => setShowSmoke(true), 0.05)
         // 両者スライドイン（ブラー解除しながら）
-        .to(playerRef.current, { x: 0, opacity: 1, filter: 'blur(0px)', skewX: 0, duration: 0.7 }, 0.02)
-        .to(cpuRef.current, { x: 0, opacity: 1, filter: 'blur(0px)', skewX: 0, duration: 0.7 }, 0.02)
-        // 着地バウンド（スケール+シェイク）
-        .addLabel('impact', '+=0.02')
-        .to([playerRef.current, cpuRef.current], { scale: 1.06, duration: 0.09, ease: 'power2.out' }, 'impact')
-        .to([playerRef.current, cpuRef.current], { scale: 1, duration: 0.12, ease: 'back.out(4)' }, 'impact+=0.09')
-        .to(containerRef.current, { x: '+=6', yoyo: true, repeat: 3, duration: 0.05, ease: 'power1.inOut' }, 'impact')
-        // 余韻（少し見せてからフェードアウト）
-        .to(containerRef.current, { opacity: 0, duration: 0.45, ease: 'power2.in' }, 'impact+=0.45')
-        .add(() => setShowSmoke(false), 'impact+=0.35');
-=======
-      gsap.set(playerRef.current, { y: '-60vh', rotate: 15 });
-      gsap.set(cpuRef.current, { y: '60vh', rotate: -15 });
-
-      gsap
-        .timeline({
-          onComplete: () => {
-            setVisible(false);
-            onComplete();
-          }
-        })
-        .to(containerRef.current, { opacity: 1, duration: 0.2, ease: 'power2.out' })
         .to(
           playerRef.current,
-          { y: 0, rotate: 0, ease: 'bounce.out', duration: 0.9 },
-          0
+          { y: 0, opacity: 1, filter: 'blur(0px)', skewY: 0, duration: 0.7 },
+          0.02
         )
         .to(
           cpuRef.current,
-          { y: 0, rotate: 0, ease: 'bounce.out', duration: 0.9 },
-          0
+          { y: 0, opacity: 1, filter: 'blur(0px)', skewY: 0, duration: 0.7 },
+          0.02
+        )
+        // 着地バウンド（スケール+シェイク）
+        .addLabel('impact', '+=0.02')
+        .to(
+          [playerRef.current, cpuRef.current],
+          { y: '+=16', scaleY: 0.9, duration: 0.09, ease: 'power2.out' },
+          'impact'
         )
         .to(
           [playerRef.current, cpuRef.current],
-          { y: '+=16', scaleY: 0.9, duration: 0.1, ease: 'power1.in' }
+          { y: '-=16', scaleY: 1, duration: 0.12, ease: 'back.out(4)' },
+          'impact+=0.09'
         )
         .to(
-          [playerRef.current, cpuRef.current],
-          { y: '-=16', scaleY: 1, duration: 0.2, ease: 'bounce.out' }
+          containerRef.current,
+          { y: '+=6', yoyo: true, repeat: 3, duration: 0.05, ease: 'power1.inOut' },
+          'impact'
         )
-        .add(() => setShowSmoke(true))
-        .to(containerRef.current, { opacity: 0, duration: 0.4, ease: 'power2.in' }, '>+=0.4')
-        .add(() => setShowSmoke(false));
->>>>>>> ab3f1d577941a0050e7f6e0a6b6c69c5d4e822ab
+        // 余韻（少し見せてからフェードアウト）
+        .to(
+          containerRef.current,
+          { opacity: 0, duration: 0.45, ease: 'power2.in' },
+          'impact+=0.45'
+        )
+        .add(() => setShowSmoke(false), 'impact+=0.35');
     });
     return () => {
       killed = true;


### PR DESCRIPTION
## Summary
- プレイヤーとCPUが上下から落ちてくるKeynote風アニメを実装
- バウンドとスモーク演出を縦方向版に統合

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8231391ec832ab3b8ce49af9dfdf0