### PR TITLE
docs: 要件定義ドキュメントへのリンク修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is a GUI for the Calorie Clash game.
 - その他の資料は[docs ディレクトリ](docs/)を参照してください。
   - [共通関数ガイド](docs/common_functions.md)
   - [Canvas チートシート（ts）](<docs/canvas_チートシート（ts）.md>)
-  - [要件定義 (MVP)](docs/merged.md)
+  - [要件定義 (MVP)](docs/要件定義.md)
 
 ## 開発ガイド
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 このディレクトリには設計メモや仕様、実装ノートが含まれます。主要なドキュメントは以下の通りです。
 
-- `merged.md`: 要件定義（MVP）と画面/機能要件まとめ
+- `要件定義.md`: 要件定義（MVP）と画面/機能要件まとめ
 - `common_functions.md`: よく使う関数・パターン集（TS/JS）
 - `canvas_チートシート（ts）.md`: Canvas API チートシート（TypeScript）
 - `html/`: 参考HTMLやスニペット


### PR DESCRIPTION
## Summary
- fix: correct broken link to requirements doc in repository README
- fix: update docs index to reference the current requirements document name

## Testing
- `cd apps/web && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a8281c99e4832aaea83cd4702cda33