### PR TITLE
web: GSAP読み込み失敗時のフォールバック処理を追加

### DIFF
--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -25,8 +25,12 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
   useEffect(() => {
     if (hasRun.current) return;
     hasRun.current = true;
-    ensureGsap().then(() => {
+    ensureGsap().then((loaded) => {
       if (killedRef.current) return;
+      if (!loaded) {
+        skipAnimation();
+        return;
+      }
       const gsap = (window as unknown as { gsap: typeof import('gsap').gsap }).gsap;
 
       // 初期状態（アンビル: 上下からブラー付きで滑り込み）
@@ -103,6 +107,8 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
           { opacity: 0, duration: 0.45, ease: 'power2.in' },
           'impact+=0.45'
         );
+    }).catch(() => {
+      skipAnimation();
     });
     return () => {
       killedRef.current = true;

--- a/apps/web/src/lib/ensureGsap.ts
+++ b/apps/web/src/lib/ensureGsap.ts
@@ -1,10 +1,26 @@
-export function ensureGsap(): Promise<void> {
+export function ensureGsap(timeout = 3000): Promise<boolean> {
   return new Promise((resolve) => {
-    if (typeof window !== 'undefined' && (window as unknown as { gsap?: unknown }).gsap) return resolve();
+    if (typeof window !== 'undefined' && (window as unknown as { gsap?: unknown }).gsap) {
+      resolve(true);
+      return;
+    }
+
     const s = document.createElement('script');
     s.src = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js';
     s.async = true;
-    s.onload = () => resolve();
+
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(tid);
+      resolve(ok);
+    };
+
+    const tid = setTimeout(() => finish(false), timeout);
+    s.onload = () => finish(true);
+    s.onerror = () => finish(false);
+
     document.head.appendChild(s);
   });
 }


### PR DESCRIPTION
## 概要
- GSAP読み込みが失敗またはタイムアウトした場合にも解決するハンドラを追加
- ゲーム開始アニメーションでGSAPの読み込み結果を確認し、失敗時は即完了

## テスト
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a902d7e2e0832a9fd9d04bbb6e0269