### PR TITLE
web: handle GSAP load timeout

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,7 +26,8 @@ export default function App() {
   useEffect(() => { saveRule(rule); }, [rule]);
 
   const startGame = () => setScreen("playerSelect");
-  const confirmPlayers = (_m: 'pvc'|'pvp') => {
+  const confirmPlayers = (mode: 'pvc'|'pvp') => {
+    void mode;
     // 初回のラウンド演出は GameScreen 側のシーケンスに任せる（VS→Round→Slot）
     setScreen('game');
   };

--- a/apps/web/src/components/effects/ImpactSmoke.tsx
+++ b/apps/web/src/components/effects/ImpactSmoke.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
+import type { CSSProperties } from 'react';
 
 // 放射状に一瞬だけ拡散する「衝突煙」
 const puff = keyframes`
@@ -30,10 +31,10 @@ export default function ImpactSmoke() {
           bg="whiteAlpha.700"
           boxShadow="0 0 18px rgba(255,255,255,0.25)"
           style={{
-            ['--dx' as any]: `${v.dx}px`,
-            ['--dy' as any]: `${v.dy}px`,
+            '--dx': `${v.dx}px`,
+            '--dy': `${v.dy}px`,
             animation: `${puff} 0.55s ease-out 0s 1 both`,
-          }}
+          } as CSSProperties}
         />
       ))}
     </Box>

--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -11,7 +11,7 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
   const [visible, setVisible] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasRun = useRef(false);
-  const tlRef = useRef<any>(null);
+  const tlRef = useRef<{ kill?: () => void } | null>(null);
   const killedRef = useRef(false);
   const [canProceed, setCanProceed] = useState(false);
 
@@ -27,80 +27,85 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
     if (hasRun.current) return;
     hasRun.current = true;
     setCanProceed(false);
-    ensureGsap().then((loaded) => {
-      if (killedRef.current) return;
-      if (!loaded) { skipAnimation(); return; }
-      const gsap = (window as unknown as { gsap: typeof import('gsap').gsap }).gsap;
+    (async () => {
+      try {
+        const loaded = await ensureGsap();
+        if (killedRef.current) return;
+        if (!loaded) { skipAnimation(); return; }
+        const gsap = (window as unknown as { gsap: typeof import('gsap').gsap }).gsap;
 
-      // 初期状態（アンビル: 上下からブラー付きで滑り込み）
-      gsap.set(containerRef.current, { opacity: 0 });
-      gsap.set(playerRef.current, {
-        y: '-60vh',
-        filter: 'blur(18px)',
-        opacity: 0,
-        rotate: 6,
-        transformOrigin: '50% 50%'
-      });
-      gsap.set(cpuRef.current, {
-        y: '60vh',
-        filter: 'blur(18px)',
-        opacity: 0,
-        rotate: -6,
-        transformOrigin: '50% 50%'
-      });
-      const flashEl = (containerRef.current?.querySelector('[data-flash]') ?? null) as HTMLElement | null;
-      if (flashEl) gsap.set(flashEl, { opacity: 0 });
+        // 初期状態（アンビル: 上下からブラー付きで滑り込み）
+        gsap.set(containerRef.current, { opacity: 0 });
+        gsap.set(playerRef.current, {
+          y: '-60vh',
+          filter: 'blur(18px)',
+          opacity: 0,
+          rotate: 6,
+          transformOrigin: '50% 50%'
+        });
+        gsap.set(cpuRef.current, {
+          y: '60vh',
+          filter: 'blur(18px)',
+          opacity: 0,
+          rotate: -6,
+          transformOrigin: '50% 50%'
+        });
+        const flashEl = (containerRef.current?.querySelector('[data-flash]') ?? null) as HTMLElement | null;
+        if (flashEl) gsap.set(flashEl, { opacity: 0 });
 
-      const tl = gsap.timeline({
-        defaults: { ease: 'expo.out' },
-        onComplete: skipAnimation,
-      });
-      tlRef.current = tl;
+        const tl = gsap.timeline({
+          defaults: { ease: 'expo.out' },
+          onComplete: skipAnimation,
+        });
+        tlRef.current = tl;
 
-      tl
-        // 背景フェードイン（薄い黒幕）
-        .to(containerRef.current, { opacity: 1, duration: 0.2 }, 0)
-        // 両者アンビルイン（ブラー解除・回転戻し）
-        .to(
-          playerRef.current,
-          { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
-          0.02
-        )
-        .to(
-          cpuRef.current,
-          { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
-          0.02
-        )
-        // インパクト
-        .addLabel('impact', '+=0.02')
-        .add(() => setShowSmoke(true), 'impact')
-        .to(flashEl, { opacity: 0.9, duration: 0.06, ease: 'power1.out' }, 'impact')
-        .to(flashEl, { opacity: 0, duration: 0.18, ease: 'power1.in' }, 'impact+=0.06')
-        .to(
-          [playerRef.current, cpuRef.current],
-          { y: '+=14', scaleY: 0.88, duration: 0.09, ease: 'power3.out' },
-          'impact'
-        )
-        .to(
-          [playerRef.current, cpuRef.current],
-          { y: '-=14', scaleY: 1, duration: 0.12, ease: 'back.out(3)' },
-          'impact+=0.09'
-        )
-        .to(
-          containerRef.current,
-          { x: '+=10', yoyo: true, repeat: 5, duration: 0.035, ease: 'power1.inOut' },
-          'impact'
-        )
-        .add(() => setShowSmoke(false), 'impact+=0.35')
-        // ユーザー操作可（次へボタン表示）
-        .add(() => setCanProceed(true), 'impact+=0.20')
-        // 余韻（少し見せてからフェードアウト）
-        .to(
-          containerRef.current,
-          { opacity: 0, duration: 0.45, ease: 'power2.in' },
-          'impact+=0.45'
-        );
-    }).catch(() => { skipAnimation(); });
+        tl
+          // 背景フェードイン（薄い黒幕）
+          .to(containerRef.current, { opacity: 1, duration: 0.2 }, 0)
+          // 両者アンビルイン（ブラー解除・回転戻し）
+          .to(
+            playerRef.current,
+            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
+            0.02
+          )
+          .to(
+            cpuRef.current,
+            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
+            0.02
+          )
+          // インパクト
+          .addLabel('impact', '+=0.02')
+          .add(() => setShowSmoke(true), 'impact')
+          .to(flashEl, { opacity: 0.9, duration: 0.06, ease: 'power1.out' }, 'impact')
+          .to(flashEl, { opacity: 0, duration: 0.18, ease: 'power1.in' }, 'impact+=0.06')
+          .to(
+            [playerRef.current, cpuRef.current],
+            { y: '+=14', scaleY: 0.88, duration: 0.09, ease: 'power3.out' },
+            'impact'
+          )
+          .to(
+            [playerRef.current, cpuRef.current],
+            { y: '-=14', scaleY: 1, duration: 0.12, ease: 'back.out(3)' },
+            'impact+=0.09'
+          )
+          .to(
+            containerRef.current,
+            { x: '+=10', yoyo: true, repeat: 5, duration: 0.035, ease: 'power1.inOut' },
+            'impact'
+          )
+          .add(() => setShowSmoke(false), 'impact+=0.35')
+          // ユーザー操作可（次へボタン表示）
+          .add(() => setCanProceed(true), 'impact+=0.20')
+          // 余韻（少し見せてからフェードアウト）
+          .to(
+            containerRef.current,
+            { opacity: 0, duration: 0.45, ease: 'power2.in' },
+            'impact+=0.45'
+          );
+      } catch {
+        if (!killedRef.current) skipAnimation();
+      }
+    })();
     return () => {
       killedRef.current = true;
       try { tlRef.current?.kill?.(); } catch { /* ignore */ }

--- a/apps/web/src/lib/ensureGsap.ts
+++ b/apps/web/src/lib/ensureGsap.ts
@@ -1,6 +1,11 @@
 export function ensureGsap(timeout = 3000): Promise<boolean> {
   return new Promise((resolve) => {
-    if (typeof window !== 'undefined' && (window as unknown as { gsap?: unknown }).gsap) {
+    if (typeof window === 'undefined') {
+      resolve(false);
+      return;
+    }
+
+    if ((window as unknown as { gsap?: unknown }).gsap) {
       resolve(true);
       return;
     }


### PR DESCRIPTION
## Summary
- ensure GSAP script resolves even on timeout/error
- skip start animation if GSAP fails to load
- clean up lint errors for build

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90abe6df4832a9bd6a313ddfcc95b