### PR TITLE
web: always show next button in start animation

### DIFF
--- a/apps/web/src/components/GameStartAnimation.tsx
+++ b/apps/web/src/components/GameStartAnimation.tsx
@@ -15,7 +15,7 @@ export default function GameStartAnimation({ onComplete, playerName = 'プレイ
   const playerRef = useRef<HTMLParagraphElement>(null);
   const cpuRef = useRef<HTMLParagraphElement>(null);
   const [showSmoke, setShowSmoke] = useState(false);
-  const { visible, containerRef, skipAnimation, canProceed } = useGameStartAnimation(
+  const { visible, containerRef, skipAnimation } = useGameStartAnimation(
     onComplete,
     playerRef as unknown as RefObject<HTMLElement>,
     cpuRef as unknown as RefObject<HTMLElement>,
@@ -35,13 +35,11 @@ export default function GameStartAnimation({ onComplete, playerName = 'プレイ
         <Text ref={cpuRef} fontWeight='black' fontSize={{ base: 'clamp(24px, 7vw, 36px)', md: '40px' }}>{cpuName}</Text>
       </VStack>
       {showSmoke && <ImpactSmoke />}
-      {canProceed && (
-        <Box position='absolute' bottom={{ base: 6, md: 8 }} left='50%' transform='translateX(-50%)'>
-          <Button bg='white' color='black' size='lg' onClick={skipAnimation} _hover={{ bg: 'gray.100' }}>
-            次へ
-          </Button>
-        </Box>
-      )}
+      <Box position='absolute' bottom={{ base: 6, md: 8 }} left='50%' transform='translateX(-50%)'>
+        <Button bg='white' color='black' size='lg' onClick={skipAnimation} _hover={{ bg: 'gray.100' }}>
+          次へ
+        </Button>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- always render "次へ" button on game start animation screen
- ensure skipping clears smoke effect and completes animation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a90fbb7c0c832a868d94636c1c61ad