### PR TITLE
ゲーム開始アニメーションの煙演出を調整

### DIFF
--- a/apps/web/src/components/hooks/useGameStartAnimation.ts
+++ b/apps/web/src/components/hooks/useGameStartAnimation.ts
@@ -65,16 +65,16 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
           // 両者アンビルイン（ブラー解除・回転戻し）
           .to(
             playerRef.current,
-            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
+            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 1, ease: 'expo.out' },
             0.02
           )
           .to(
             cpuRef.current,
-            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 0.65, ease: 'expo.out' },
+            { y: 0, opacity: 1, filter: 'blur(0px)', rotate: 0, duration: 1, ease: 'expo.out' },
             0.02
           )
           // インパクト
-          .addLabel('impact', '+=0.02')
+          .addLabel('impact', 1)
           .add(() => setShowSmoke(true), 'impact')
           .to(flashEl, { opacity: 0.9, duration: 0.06, ease: 'power1.out' }, 'impact')
           .to(flashEl, { opacity: 0, duration: 0.18, ease: 'power1.in' }, 'impact+=0.06')
@@ -93,7 +93,7 @@ export function useGameStartAnimation<T extends HTMLElement, U extends HTMLEleme
             { x: '+=10', yoyo: true, repeat: 5, duration: 0.035, ease: 'power1.inOut' },
             'impact'
           )
-          .add(() => setShowSmoke(false), 'impact+=0.35')
+          .add(() => setShowSmoke(false), 'impact+=0.21')
           // ユーザー操作可（次へボタン表示）
           .add(() => setCanProceed(true), 'impact+=0.20')
           // 余韻（少し見せてからフェードアウト）


### PR DESCRIPTION
## 概要
- プレイヤー/CPUアニメーションを1秒に戻し、煙演出のタイミングを調整
- 着地後に煙を消しつつ既存のバウンド・シェイク・フェードアウトを保持

## 動作確認
- `npm test` (スクリプト未定義を確認)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a912ec7c60832aa086e714fb35c1e8