### PR TITLE
docs: HTMLモックアップ削除に伴うリンク整理

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,6 @@
 - `要件定義.md`: 要件定義（MVP）と画面/機能要件まとめ
 - `common_functions.md`: よく使う関数・パターン集（TS/JS）
 - `canvas_チートシート（ts）.md`: Canvas API チートシート（TypeScript）
-- `html/`: 参考HTMLやスニペット
 
 プロジェクト全体の概要や開発手順はリポジトリ直下の `README.md` を参照してください。
 

--- a/docs/要件定義.md
+++ b/docs/要件定義.md
@@ -133,8 +133,7 @@ export interface CsvImportResult {
 
 - 目的:
   じゃんけんによりラウンド結果を決定し、スコアを加算する対戦フェーズ。
-- プロトタイプ:
-  [docs/html/calorie_clash_janken_battle_battle.html](html/calorie_clash_janken_battle_battle.html)
+- プロトタイプ: HTMLモックアップは削除されました
 
 ## 画面構成
 
@@ -186,8 +185,7 @@ export interface CsvImportResult {
 
 - 目的:
   一定時間内にタップで「食べる」アクションを行い、満腹度に応じた進捗で料理を完食。合計カロリーを競うフェーズ。
-- プロトタイプ:
-  [docs/html/calorie_clash_mash_phase_mash.html](html/calorie_clash_mash_phase_mash.html)
+- プロトタイプ: HTMLモックアップは削除されました
 
 ## ルール/パラメータ
 
@@ -257,8 +255,7 @@ export interface CsvImportResult {
 
 - 目的:
   タイトル画面上に重なるモーダルで、音量/表示/テーマ/言語など基礎設定を変更・保存できるようにする。
-- プロトタイプ:
-  [docs/html/calorie_clash_options_screen_mvp_options.html](html/calorie_clash_options_screen_mvp_options.html)
+- プロトタイプ: HTMLモックアップは削除されました
 
 ## 画面構成
 
@@ -326,8 +323,7 @@ export interface CsvImportResult {
 
 - 目的:
   ゲーム起動時のエントリーポイント。ロゴ提示と主要メニューへの導線を提供する。
-- プロトタイプ:
-  [docs/html/calorie_clash_title_screen_mvp_title.html](html/calorie_clash_title_screen_mvp_title.html)
+- プロトタイプ: HTMLモックアップは削除されました
 
 ## 画面構成
 


### PR DESCRIPTION
## 概要
- docs/README から存在しない `html/` 項目を削除
- 要件定義の各セクションで削除済みHTMLモックアップのリンクを除去

## テスト
- `cd apps/web && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a92af42f20832aa4bceee73f8f7691